### PR TITLE
refactor: update secondary data

### DIFF
--- a/src/contexts/rper-context.tsx
+++ b/src/contexts/rper-context.tsx
@@ -1,17 +1,33 @@
 import { createContext, useCallback, useContext, useState } from 'react'
 import api from '../services/api'
 
-interface Rper {
+export interface User {
+  user_id: string
+  name: string
+  avatar_url: string
+}
+
+interface SecondaryData {
+  content: string
+  editable: boolean
+}
+
+export interface Rper {
   name: string
   coordinator_id: string
   rper_id: string
+  secondaryData: SecondaryData
+  coordinator: User
+  members: User[]
   created_at: string
   updated_at: string
 }
 
 interface RperContextData {
   rpers: Rper[] | null
+  rper: Rper | null
   getRpers: () => Promise<void>
+  findRper: (rper_id: string) => Promise<void>
 }
 
 const RperContext = createContext({} as RperContextData)
@@ -20,6 +36,7 @@ const RperProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [rpers, setRpers] = useState<Rper[] | null>(null)
+  const [rper, setRper] = useState<Rper | null>(null)
 
   const getRpers = useCallback(async () => {
     try {
@@ -30,8 +47,20 @@ const RperProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, [setRpers])
 
+  const findRper = useCallback(
+    async (rper_id: string) => {
+      try {
+        const response = await api.get<Rper>(`rpers/${rper_id}`)
+        setRper(response.data)
+      } catch (error) {
+        console.log(error)
+      }
+    },
+    [setRper],
+  )
+
   return (
-    <RperContext.Provider value={{ rpers, getRpers }}>
+    <RperContext.Provider value={{ rpers, rper, getRpers, findRper }}>
       {children}
     </RperContext.Provider>
   )

--- a/src/pages/dashboard/acknowledgment/index.tsx
+++ b/src/pages/dashboard/acknowledgment/index.tsx
@@ -8,7 +8,8 @@ const Acknowledgment: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/collectivity-registration/index.tsx
+++ b/src/pages/dashboard/collectivity-registration/index.tsx
@@ -8,7 +8,8 @@ const CollectivityRegistration: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/contact-collectivity/index.tsx
+++ b/src/pages/dashboard/contact-collectivity/index.tsx
@@ -8,7 +8,8 @@ const ContactCollectivity: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/daily-routines/index.tsx
+++ b/src/pages/dashboard/daily-routines/index.tsx
@@ -8,7 +8,8 @@ const DailyRoutines: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/editor-component/index.tsx
+++ b/src/pages/dashboard/editor-component/index.tsx
@@ -3,14 +3,18 @@ import { RiExchangeFill } from 'react-icons/ri'
 import Button from '../../../components/button'
 import TextEditor from '../../../components/text-editor'
 import { ActionButtons, Container } from './styles'
+import { Rper } from '../../../contexts/rper-context'
+import { isMember } from '../../../utils/is-rper-member'
+import { useAuth } from '../../../contexts/auth-context'
 
 interface TitleProp {
   title: string
+  isReadOnly: boolean
+  rper: Rper | null
+  editable: boolean
   handleTextChange: (text: string) => void
   handleSave: () => void
-  isReadOnly: boolean
   handleReadOnly: (readonly: boolean) => void
-  content: string
 }
 
 const EditorComponent: React.FC<TitleProp> = ({
@@ -19,8 +23,11 @@ const EditorComponent: React.FC<TitleProp> = ({
   handleTextChange,
   handleReadOnly,
   isReadOnly,
-  content,
+  rper,
+  editable,
 }) => {
+  const { user } = useAuth()
+
   const handleEnableEdition = useCallback(() => {
     handleReadOnly(false)
   }, [])
@@ -29,6 +36,9 @@ const EditorComponent: React.FC<TitleProp> = ({
     handleReadOnly(value)
   }
 
+  const hasPermissionToEdit =
+    rper?.coordinator_id === user.user_id || isMember(rper, user.user_id)
+
   return (
     <Container>
       <h2>
@@ -36,10 +46,16 @@ const EditorComponent: React.FC<TitleProp> = ({
         {title}
       </h2>
       <ActionButtons>
-        <Button onClick={handleEnableEdition} disabled={!isReadOnly}>
+        <Button
+          onClick={handleEnableEdition}
+          disabled={!isReadOnly || !editable || !hasPermissionToEdit}
+        >
           Enable Edition
         </Button>
-        <Button disabled={isReadOnly} onClick={handleSave}>
+        <Button
+          disabled={isReadOnly || !hasPermissionToEdit}
+          onClick={handleSave}
+        >
           Save
         </Button>
       </ActionButtons>
@@ -47,7 +63,7 @@ const EditorComponent: React.FC<TitleProp> = ({
         isReadOnly={isReadOnly}
         updateReadOnlyFunction={updateReadOnly}
         handleTextChange={handleTextChange}
-        content={content}
+        content={rper?.secondaryData.content || ''}
       />
     </Container>
   )

--- a/src/pages/dashboard/election-of-priorities/index.tsx
+++ b/src/pages/dashboard/election-of-priorities/index.tsx
@@ -8,7 +8,8 @@ const ElectionOfPriorities: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/extra-information/index.tsx
+++ b/src/pages/dashboard/extra-information/index.tsx
@@ -8,7 +8,8 @@ const ExtraInformation: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/final-considerations/index.tsx
+++ b/src/pages/dashboard/final-considerations/index.tsx
@@ -8,7 +8,8 @@ const FinalConsiderations: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/focus-group-guide/index.tsx
+++ b/src/pages/dashboard/focus-group-guide/index.tsx
@@ -8,7 +8,8 @@ const FocusGroupGuide: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/historical-mapping/index.tsx
+++ b/src/pages/dashboard/historical-mapping/index.tsx
@@ -8,7 +8,8 @@ const HistoricalMapping: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/input-and-output/index.tsx
+++ b/src/pages/dashboard/input-and-output/index.tsx
@@ -8,7 +8,8 @@ const InputAndOutput: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/interview-focus-group/index.tsx
+++ b/src/pages/dashboard/interview-focus-group/index.tsx
@@ -8,7 +8,8 @@ const InterviewFocusGroup: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/interview-guide/index.tsx
+++ b/src/pages/dashboard/interview-guide/index.tsx
@@ -8,7 +8,8 @@ const InterviewGuide: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/presentation/index.tsx
+++ b/src/pages/dashboard/presentation/index.tsx
@@ -8,7 +8,8 @@ const Presentation: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/reality-and-obj-matrix/index.tsx
+++ b/src/pages/dashboard/reality-and-obj-matrix/index.tsx
@@ -8,7 +8,8 @@ const RealityAndObjMatrix: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/seasonal-calendar/index.tsx
+++ b/src/pages/dashboard/seasonal-calendar/index.tsx
@@ -8,7 +8,8 @@ const SeasonalCalendar: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/secondary-data/index.tsx
+++ b/src/pages/dashboard/secondary-data/index.tsx
@@ -5,38 +5,46 @@ import EditorComponent from '../editor-component'
 import { Content, Main } from '../styles'
 import { useParams } from 'react-router-dom'
 import api from '../../../services/api'
-import { Rper } from '../types'
+import { useRper } from '../../../contexts/rper-context'
 
 const SecondaryData: React.FC = () => {
   const { id } = useParams()
+  const { rper, findRper } = useRper()
   const [contentText, setContentText] = useState('')
   const [readOnly, setReadOnly] = useState(true)
-  const [rper, setRper] = useState<Rper>()
-
-  const getRper = async () => {
-    try {
-      const response = await api.get<Rper>(`rpers/${id}`)
-
-      setRper(response.data)
-    } catch (error) {
-      console.log(error)
-    }
-  }
 
   const handleSave = async () => {
     try {
       await api.put(`rpers/${id}/secondary-data`, {
         content: contentText,
+        editable: !readOnly,
       })
-      setReadOnly(true)
-      setContentText(contentText)
+      findRper(`${id}`)
+
+      setReadOnly(!rper?.secondaryData.editable)
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  const handleUpdateRperEditable = async (editable: boolean) => {
+    try {
+      await api.put(`rpers/${id}/secondary-data`, {
+        editable,
+      })
     } catch (error) {
       console.log(error)
     }
   }
 
   useEffect(() => {
-    getRper()
+    findRper(`${id}`)
+
+    if (rper?.secondaryData.editable === true) {
+      handleUpdateRperEditable(!rper?.secondaryData.editable)
+    }
+
+    setReadOnly(!rper?.secondaryData.editable)
   }, [])
 
   return (
@@ -52,7 +60,8 @@ const SecondaryData: React.FC = () => {
             handleSave={handleSave}
             isReadOnly={readOnly}
             handleReadOnly={setReadOnly}
-            content={contentText || rper?.secondaryData.content || ''}
+            rper={rper}
+            editable={!!rper?.secondaryData.editable}
           />
         </Content>
       </Main>

--- a/src/pages/dashboard/summary/index.tsx
+++ b/src/pages/dashboard/summary/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable indent */
 import { useEffect, useState } from 'react'
 import { RiExchangeFill } from 'react-icons/ri'
-import Carousel from './carousel'
 import Info from './info'
 import {
   Container,
@@ -13,28 +12,18 @@ import {
   Avatar,
 } from './styles'
 import { useParams } from 'react-router-dom'
-import api from '../../../services/api'
-import { Rper } from '../types'
 import Menu from '../../../components/menu'
 import Header from '../../../components/header'
 import { Content, Main } from '../styles'
+import { useRper } from '../../../contexts/rper-context'
 
 const Summary: React.FC = () => {
-  const [progress, setProgress] = useState(70)
-  const [rper, setRper] = useState<Rper>()
   const { id } = useParams()
-
-  const getRper = async () => {
-    try {
-      const response = await api.get<Rper>(`rpers/${id}`)
-      setRper(response.data)
-    } catch (error) {
-      console.log(error)
-    }
-  }
+  const [progress, setProgress] = useState(70)
+  const { rper, findRper } = useRper()
 
   useEffect(() => {
-    getRper()
+    findRper(`${id}`)
   }, [])
 
   return (

--- a/src/pages/dashboard/tasks-and-calendar/index.tsx
+++ b/src/pages/dashboard/tasks-and-calendar/index.tsx
@@ -8,7 +8,8 @@ const TasksAndCalendar: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/team/index.tsx
+++ b/src/pages/dashboard/team/index.tsx
@@ -14,7 +14,6 @@ import {
   AvatarContainer,
   MemberInfoContainer,
   CoordinatorButtonsManagementContainer,
-  PromoteToCoordinatorButton,
   RemoveMemberButton,
 } from './styles'
 
@@ -22,10 +21,10 @@ import Header from '../../../components/header'
 import { Content, Main } from '../styles'
 import Menu from '../../../components/menu'
 import api from '../../../services/api'
-import { Rper, User } from '../types'
 import { useParams } from 'react-router-dom'
 import { useAuth } from '../../../contexts/auth-context'
 import { RemoveMemberRper } from './types'
+import { User, useRper } from '../../../contexts/rper-context'
 
 const Team: React.FC = () => {
   const { id } = useParams()
@@ -34,17 +33,8 @@ const Team: React.FC = () => {
   const [typeOfConfirmationModal, setTypeOfConfirmationModal] = useState('')
   const [transferCoord, setTransferCoord] = useState('')
   const [removeMember, setRemoveMember] = useState({})
-  const [rper, setRper] = useState<Rper>()
   const [users, setUsers] = useState<User[]>()
-
-  const getRper = async () => {
-    try {
-      const response = await api.get<Rper>(`rpers/${id}`)
-      setRper(response.data)
-    } catch (error) {
-      console.log(error)
-    }
-  }
+  const { rper, findRper } = useRper()
 
   const getUsers = async () => {
     try {
@@ -62,7 +52,7 @@ const Team: React.FC = () => {
         users_ids: updatedMembersIds,
       })
 
-      await getRper()
+      await findRper(`${id}`)
       await getUsers()
     } catch (error) {
       console.log(error)
@@ -70,7 +60,7 @@ const Team: React.FC = () => {
   }
 
   useEffect(() => {
-    getRper()
+    findRper(`${id}`)
     getUsers()
   }, [])
 
@@ -104,7 +94,7 @@ const Team: React.FC = () => {
     try {
       await api.patch(`rpers/${rper_id}/members/${user_id}`)
 
-      await getRper()
+      await findRper(`${id}`)
       await getUsers()
     } catch (error) {
       console.log(error)

--- a/src/pages/dashboard/team/modals/modal-add-team/index.tsx
+++ b/src/pages/dashboard/team/modals/modal-add-team/index.tsx
@@ -9,10 +9,10 @@ import {
   ButtonContainer,
   Avatar,
 } from './styles'
-import { Rper, User } from '../../../types'
+import { Rper, User } from '../../../../../contexts/rper-context'
 
 interface AddTeamModalProps {
-  rper: Rper | undefined
+  rper: Rper | null
   users: User[] | undefined
   handleMembers: (membersIds: string[]) => void
 }

--- a/src/pages/dashboard/themes-framework/index.tsx
+++ b/src/pages/dashboard/themes-framework/index.tsx
@@ -8,7 +8,8 @@ const ThemesFramework: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/transect-walk/index.tsx
+++ b/src/pages/dashboard/transect-walk/index.tsx
@@ -8,7 +8,8 @@ const TransectWalk: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/pages/dashboard/types.ts
+++ b/src/pages/dashboard/types.ts
@@ -3,18 +3,3 @@ export type User = {
   name: string
   avatar_url: string
 }
-
-type SecondaryData = {
-  content: string
-}
-
-export type Rper = {
-  name: string
-  coordinator_id: string
-  coordinator: User
-  rper_id: string
-  members: User[]
-  secondaryData: SecondaryData
-  created_at: string
-  updated_at: string
-}

--- a/src/pages/dashboard/venn-diagram/index.tsx
+++ b/src/pages/dashboard/venn-diagram/index.tsx
@@ -8,7 +8,8 @@ const VennDiagram: React.FC = () => {
       handleSave={() => null}
       handleTextChange={() => null}
       isReadOnly
-      content=""
+      rper={null}
+      editable
     />
   )
 }

--- a/src/utils/is-rper-member.ts
+++ b/src/utils/is-rper-member.ts
@@ -1,0 +1,5 @@
+import { Rper } from '../contexts/rper-context'
+
+export function isMember(rper: Rper | null, user_id: string) {
+  return rper?.members.some(member => member.user_id === user_id)
+}


### PR DESCRIPTION
## Qual o problema inicial? 📝
- Em `Secondary Data`, o valor de `readOnly` só era atualizado com a interação do usuário pelos botões `Enable Edition` e `Save`.
- Ao digitar valores nos campos, o cursor está sendo direcionado ao começo do container.
- Qualquer pessoa pode editar o secondary data.
## Como esse problema foi resolvido? 🤔
- Todo o processo de edição do campo agora está amarrado a propriedade `editable` do rper.
- Retirado o  estado contentText na renderização do campo.
- Realizado trava para somente coordenador e membros possam editar secondary data.
## Como testar? 👀
- Acessar `Secondary Data` com um usuário que possui permissão, caso o RPER esteja com a propriedade `editable` = true, o botão `Enable Edition` estará desabilitado e será possível digitar qualquer info no campo.
- Ao acessar o mesmo recurso com outro usuário habilitado, caso ele já esteja sendo editado, não será possível editar também.
- Ao acessar o mesmo recurso com um usuário não habilitado, ele não pode realizar nenhuma edição.
## Aguardando 💭
<!-- especificar o motivo (linkar jyra ou thread no slack, caso haja)-->
###### Adicionou uma nova lib ao projeto? ⚙️:
- [ ] Se sim, qual? <!-- Colocar o nome aqui -->
- [X] Não.
###### Como pessoa dona do PR, afirmo que fiz as seguintes verificações ✅:
- [X] Testei no mobile
- [X] Revisei o código.
- [X] Rodei os linters.
- [X] Revisei o layout.