### PR TITLE
[PR-2] - Ao clicar fora da página, deve-se salvar automaticamente o conteúdo

### DIFF
--- a/src/pages/dashboard/secondary-data/index.tsx
+++ b/src/pages/dashboard/secondary-data/index.tsx
@@ -70,6 +70,7 @@ const SecondaryData: React.FC = () => {
   useBeforeUnload(() => {
     handleSave()
     handleRemoveEditingResource()
+    setReadOnly(true)
   })
 
   return (


### PR DESCRIPTION
## Qual o problema inicial? 📝
https://raulneto90.atlassian.net/browse/PR-2

## Como esse problema foi resolvido? 🤔
- Setei o estado de readonly quando ocorrer o evento de fechamento da página ou troca de URL.

## Como testar? 👀
- Acessar o sistema
- Acessar um RPER e, em seguida, ir para secondary-data.
- Fechar a aba/trocar a url.
- Acessar novamente e ver se há possibilidade de edição novamente.

###### Adicionou uma nova lib ao projeto? ⚙️:
- [ ] Se sim, qual? <!-- Colocar o nome aqui -->
- [X] Não.

###### Como pessoa dona do PR, afirmo que fiz as seguintes verificações ✅:
- [X] Testei no mobile
- [X] Revisei o código.
- [X] Rodei os linters.
- [X] Revisei o layout.