### PR TITLE
[PR-15] - Implementar erros ao salvar conteúdo do RPER

### DIFF
--- a/src/pages/dashboard/acknowledgment/index.tsx
+++ b/src/pages/dashboard/acknowledgment/index.tsx
@@ -8,11 +8,13 @@ import api, { handleUploadImage } from '../../../services/api'
 import { useRper } from '../../../contexts/rper-context'
 import { useAuth } from '../../../contexts/auth-context'
 import { MAX_TIME_WITHOUT_EDITING } from '../../../utils/constants'
+import { useToast } from '../../../contexts/toast-context'
 
 const Acknowledgment: React.FC = () => {
   const { id } = useParams()
   const { rper, findRper, findEditingResource } = useRper()
   const { user } = useAuth()
+  const { addToast } = useToast()
   const [contentText, setContentText] = useState('')
   const [readOnly, setReadOnly] = useState(true)
 
@@ -47,6 +49,13 @@ const Acknowledgment: React.FC = () => {
       setReadOnly(true)
       findRper(`${id}`)
     } catch (error) {
+      addToast({
+        type: 'error',
+        title: 'Saving content',
+        description:
+          'Oops! Something wrong happening while saving content. Please try again',
+      })
+
       console.log(error)
     }
   }

--- a/src/pages/dashboard/finalconsideration/index.tsx
+++ b/src/pages/dashboard/finalconsideration/index.tsx
@@ -8,11 +8,13 @@ import api, { handleUploadImage } from '../../../services/api'
 import { useRper } from '../../../contexts/rper-context'
 import { useAuth } from '../../../contexts/auth-context'
 import { MAX_TIME_WITHOUT_EDITING } from '../../../utils/constants'
+import { useToast } from '../../../contexts/toast-context'
 
 const FinalConsideration: React.FC = () => {
   const { id } = useParams()
   const { rper, findRper, findEditingResource } = useRper()
   const { user } = useAuth()
+  const { addToast } = useToast()
   const [contentText, setContentText] = useState('')
   const [readOnly, setReadOnly] = useState(true)
 
@@ -47,6 +49,12 @@ const FinalConsideration: React.FC = () => {
       setReadOnly(true)
       findRper(`${id}`)
     } catch (error) {
+      addToast({
+        type: 'error',
+        title: 'Saving content',
+        description:
+          'Oops! Something wrong happening while saving content. Please try again',
+      })
       console.log(error)
     }
   }

--- a/src/pages/dashboard/historical-mapping/index.tsx
+++ b/src/pages/dashboard/historical-mapping/index.tsx
@@ -8,11 +8,13 @@ import { MAX_TIME_WITHOUT_EDITING } from '../../../utils/constants'
 import EditorComponent from '../editor-component'
 import { Main, Content } from '../styles'
 import Menu from '../../../components/menu'
+import { useToast } from '../../../contexts/toast-context'
 
 const HistoricalMapping: React.FC = () => {
   const { id } = useParams()
   const { rper, findRper, findEditingResource } = useRper()
   const { user } = useAuth()
+  const { addToast } = useToast()
   const [contentText, setContentText] = useState('')
   const [readOnly, setReadOnly] = useState(true)
 
@@ -46,7 +48,13 @@ const HistoricalMapping: React.FC = () => {
       await handleRemoveEditingResource()
       setReadOnly(true)
       findRper(`${id}`)
-    } catch (error) {
+    } catch (error: any) {
+      addToast({
+        type: 'error',
+        title: 'Saving content',
+        description:
+          'Oops! Something wrong happening while saving content. Please try again',
+      })
       console.log(error)
     }
   }

--- a/src/pages/dashboard/secondary-data/index.tsx
+++ b/src/pages/dashboard/secondary-data/index.tsx
@@ -8,11 +8,13 @@ import api, { handleUploadImage } from '../../../services/api'
 import { useRper } from '../../../contexts/rper-context'
 import { useAuth } from '../../../contexts/auth-context'
 import { MAX_TIME_WITHOUT_EDITING } from '../../../utils/constants'
+import { useToast } from '../../../contexts/toast-context'
 
 const SecondaryData: React.FC = () => {
   const { id } = useParams()
   const { rper, findRper, findEditingResource } = useRper()
   const { user } = useAuth()
+  const { addToast } = useToast()
   const [contentText, setContentText] = useState('')
   const [readOnly, setReadOnly] = useState(true)
 
@@ -47,6 +49,12 @@ const SecondaryData: React.FC = () => {
       setReadOnly(true)
       findRper(`${id}`)
     } catch (error) {
+      addToast({
+        type: 'error',
+        title: 'Saving content',
+        description:
+          'Oops! Something wrong happening while saving content. Please try again',
+      })
       console.log(error)
     }
   }

--- a/src/pages/dashboard/transect-walk/index.tsx
+++ b/src/pages/dashboard/transect-walk/index.tsx
@@ -8,11 +8,13 @@ import { MAX_TIME_WITHOUT_EDITING } from '../../../utils/constants'
 import EditorComponent from '../editor-component'
 import { Main, Content } from '../styles'
 import Menu from '../../../components/menu'
+import { useToast } from '../../../contexts/toast-context'
 
 const TransectWalk: React.FC = () => {
   const { id } = useParams()
   const { rper, findRper, findEditingResource } = useRper()
   const { user } = useAuth()
+  const { addToast } = useToast()
   const [contentText, setContentText] = useState('')
   const [readOnly, setReadOnly] = useState(true)
 
@@ -46,7 +48,13 @@ const TransectWalk: React.FC = () => {
       await handleRemoveEditingResource()
       setReadOnly(true)
       findRper(`${id}`)
-    } catch (error) {
+    } catch (error: any) {
+      addToast({
+        type: 'error',
+        title: 'Saving content',
+        description:
+          'Oops! Something wrong happening while saving content. Please try again',
+      })
       console.log(error)
     }
   }


### PR DESCRIPTION
## Qual o problema inicial? 📝
https://raulneto90.atlassian.net/browse/PR-15

## Como esse problema foi resolvido? 🤔
- Ao ocorrer um erro ao salvar conteúdo do RPER, foi implementado um toast de erro genérico, com intuito de informar ao usuário que algo aconteceu.

## Como testar? 👀
- Acessar o sistema.
- Acessar um RPER existente ou criar um novo.
- Acessar qualquer conteúdo já implementado (secondaryData, historicalMapping por ex).
- Simular um erro qualquer na API. Deverá retornar um toast de erro.

###### Adicionou uma nova lib ao projeto? ⚙️:
- [ ] Se sim, qual? <!-- Colocar o nome aqui -->
- [X] Não.

###### Como pessoa dona do PR, afirmo que fiz as seguintes verificações ✅:
- [X] Testei no mobile
- [X] Revisei o código.
- [X] Rodei os linters.
- [X] Rodei os testes e adicionei novos quando necessário.
- [X] Revisei o layout.